### PR TITLE
Create directory to contain shell config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - Handle the case when the `$SHELL` variable is unset (#13)
+- Make sure directory containing shell config exists before updating shell
+  config (#10)
 
 ### Added
 

--- a/install.sh
+++ b/install.sh
@@ -403,6 +403,7 @@ main () {
 
     case "$should_update_shell_config" in
         y)
+            mkdir -p "$(dirname "$shell_config")"
             shell_config_code >> "$shell_config"
             echo
             success "Added Dune setup commands to $shell_config!"


### PR DESCRIPTION
Sometimes it doesn't already exist, such as when using fish on a machine that doesn't yet have a fish shell. Fish's default config file is ~/.config/fish/fish.config, and the ~/.config/fish directory needs to be created before creating the config file if it doesn't already exist.