### PR TITLE
Allow ~ paths at install root prompt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 
 - Clarify that pressing enter takes the default value (#9)
 - Include shell config filename when printing existing dune config (#12)
+- Allow paths beginning with '~' to be entered at install root prompt (#11)
 
 ## v1
 

--- a/install.sh
+++ b/install.sh
@@ -279,6 +279,11 @@ main () {
             /*)
                 install_root=$choice
                 ;;
+            '~'/*)
+                install_root=$(echo "$choice" | sed "s#~#$HOME#")
+                echo
+                warn "Expanding $choice to $install_root"
+                ;;
             *)
                 echo
                 warn "Unrecognized choice: $choice"

--- a/interactive_generic.tcl
+++ b/interactive_generic.tcl
@@ -1,0 +1,25 @@
+#!/usr/bin/env expect
+# Expect script for interactively running the installation script. This script
+# takes arguments which it passes to the interactive prompts of the install
+# script.
+
+set timeout 10
+
+set install_script [lindex $argv 0]
+set version [lindex $argv 1]
+set install_root [lindex $argv 2]
+
+# Create a temporary directory to store the shell config
+set tmp [exec mktemp -d]
+
+spawn "$install_script" "$version" --shell bash --shell-config "$tmp/bashrc"
+
+expect "> "
+send "$install_root\r"
+expect "Dune successfully installed"
+
+expect "Would you like these lines to be appended to $tmp/bashrc?"
+send "y\r"
+
+expect "This installer will now exit."
+

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -1,6 +1,9 @@
-# Dockerfile that uses the install script to install Dune system-wide and
-# asserts some facts to confirm that the installation succeeded. Build the
+# Dockerfile to exercise the install script in various scenarios. Build the
 # dockerfile to run the test.
+
+###############################################################################
+# Use the install script to install Dune system-wide and assert some facts to
+# confirm that the installation succeeded.
 FROM alpine:3.22.0
 RUN apk update && apk add curl
 ENV DUNE_VERSION="3.19.1"
@@ -12,11 +15,13 @@ RUN ./install.sh $DUNE_VERSION --install-root /usr --no-update-shell-config
 # Test that dune was installed to the expected location:
 RUN test $(which dune) = "/usr/bin/dune"
 
-# Test that the installed dune can be executed and that it reports being the expected version:
+# Test that the installed dune can be executed and that it reports being the
+# expected version:
 RUN test $(dune --version) = "$DUNE_VERSION"
 
-# Start from a fresh layer, and this time install dune having the script first
-# look up the latest released version of dune.
+###############################################################################
+# Install dune having the script first look up the latest released version of
+# dune.
 FROM alpine:3.22.0
 RUN apk update && apk add curl git
 COPY install.sh .
@@ -26,3 +31,20 @@ RUN ./install.sh --install-root /usr --no-update-shell-config
 
 # Test that dune was installed to the expected location:
 RUN test $(which dune) = "/usr/bin/dune"
+
+###############################################################################
+# Test that the install script can handle a user entering a path beginning with
+# '~` at the prompt for install directory.
+FROM alpine:3.22.0
+RUN apk update && apk add curl expect
+ENV DUNE_VERSION="3.19.1"
+
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+COPY install.sh interactive_generic.tcl .
+
+# Run the interactive installer using expect to enter text at interactive
+# prompts.
+RUN ./interactive_generic.tcl ./install.sh 3.19.1 '~/.local'
+RUN test -f ~/.local/bin/dune


### PR DESCRIPTION
Previously users needed to enter paths beginning with '/', but they may wish to instead enter paths beginning with '~'. To test this functionality, this change introduces a new expect script which takes command line arguments and uses them to respond to interactive prompts.