### PR TITLE
Include config filename when printing existing config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - Clarify that pressing enter takes the default value (#9)
+- Include shell config filename when printing existing dune config (#12)
 
 ## v1
 

--- a/install.sh
+++ b/install.sh
@@ -359,7 +359,7 @@ main () {
         echo "$dune_env_call"
     }
 
-    if [ -f "$shell_config" ] && match=$(grep -n "$(echo "$dune_env_call" | sed 's#\$#\\$#')" "$shell_config"); then
+    if [ -f "$shell_config" ] && match=$(grep -Hn "$(echo "$dune_env_call" | sed 's#\$#\\$#')" "$shell_config"); then
         info "It appears your shell config file ($shell_config) is already set up correctly as it contains the line:"
         echo
         info "$match"


### PR DESCRIPTION
When the user's shell configuration already includes dune's configurataion the installer prints the line from the config that indicates that dune's config is already present along with the line number. This adds the filename to the same line.

An example of the output is:
```
/home/s/.bashrc:255:__dune_env $HOME/.dune
```