### PR TITLE
Handle case where $SHELL is unset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Handle the case when the `$SHELL` variable is unset (#13)
+
 ### Added
 
 - Look up latest version if no version was specified (#7)

--- a/test_errors.expected_output
+++ b/test_errors.expected_output
@@ -14,7 +14,7 @@ Options:
 --update-shell-config     Always the shell config (e.g. .bashrc) if necessary
 --no-update-shell-config  Never update the shell config (e.g. .bashrc)
 --shell-config PATH       Use this file as your shell config when updating the shell config
---shell SHELL             One of: bash, zsh, fish. Installer will treat this as your shell
+--shell SHELL             One of: bash, zsh, fish, sh. Installer will treat this as your shell. Use 'sh' for minimal posix shells such as ash
 
 
 Test that omitting the argument to --install-root is an error:
@@ -34,4 +34,4 @@ Test that --shell requires an argument:
 
 
 Test that --shell validates its argument:
-[0;31merror[0m: --shell must be passed one of bash, zsh, fish. Got foo.
+[0;31merror[0m: --shell must be passed one of bash, zsh, fish, sh. Got foo.


### PR DESCRIPTION
Previously the installer would try to use '*' as the shell when the $SHELL variable was unset which doesn't make sense. This change introduces logic for trying to infer the user's login shell from other environment variables, and falls back to 'sh' and prints a warning if it's not clear what the user's shell is.

Also adds some logic for installing dune when the user's shell is sh (and other minimal posix shells ash and dash) by modifying ~/.profile.