### PR TITLE
Add debugging options to override the url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 ### Added
 
 - Look up latest version if no version was specified (#7)
+- Add debugging options to override the url (#15)
 
 ### Changed
 

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -254,6 +254,29 @@ RUN $SHELL -c 'test $(which dune) = "/home/user/.local/bin/dune"'
 
 
 ###############################################################################
+# Test the options to override the tarball url and directory name. These flags
+# can be used to install dune from a tarball at an arbitrary url, so just point
+# them at the official release anyway as this will still exercise the logic for
+# downloading dune from a url passed on the command-line.
+FROM base AS test10
+RUN apk update && apk add curl
+ENV DUNE_VERSION="3.19.1"
+
+# Install dune system-wide using the install script:
+RUN ./install.sh $DUNE_VERSION --install-root /usr --no-update-shell-config \
+    --debug-override-url https://github.com/ocaml-dune/dune-bin/releases/download/3.19.1/dune-3.19.1-x86_64-unknown-linux-musl.tar.gz \
+    --debug-tarball-dir dune-3.19.1-x86_64-unknown-linux-musl
+
+# Test that dune was installed to the expected location:
+RUN test $(which dune) = "/usr/bin/dune"
+
+# Test that the installed dune can be executed and that it reports being the
+# expected version:
+RUN test $(dune --version) = "$DUNE_VERSION"
+
+
+
+###############################################################################
 # Final stage that copies the install scripts from the previous stage to force
 # them to be rerun after the script changes. Docker won't rerun stages which
 # don't affect the final stage, even if their inputs change.
@@ -267,3 +290,4 @@ COPY --from=test6 /install.sh .
 COPY --from=test7 /install.sh .
 COPY --from=test8 /install.sh .
 COPY --from=test9 /install.sh .
+COPY --from=test10 /install.sh .

--- a/test_errors.expected_output
+++ b/test_errors.expected_output
@@ -15,6 +15,8 @@ Options:
 --no-update-shell-config  Never update the shell config (e.g. .bashrc)
 --shell-config PATH       Use this file as your shell config when updating the shell config
 --shell SHELL             One of: bash, zsh, fish, sh. Installer will treat this as your shell. Use 'sh' for minimal posix shells such as ash
+--debug-override-url URL  Download dune tarball from given url (debugging only)
+--debug-tarball-dir DIR   Name of root directory inside tarball (debugging only)
 
 
 Test that omitting the argument to --install-root is an error:
@@ -35,3 +37,11 @@ Test that --shell requires an argument:
 
 Test that --shell validates its argument:
 [0;31merror[0m: --shell must be passed one of bash, zsh, fish, sh. Got foo.
+
+
+Test that --debug-override-url requires an argument:
+[0;31merror[0m: --debug-override-url must be passed an argument
+
+
+Test that --debug-tarball-dir requires an argument:
+[0;31merror[0m: --debug-tarball-dir must be passed an argument

--- a/test_errors.sh
+++ b/test_errors.sh
@@ -38,6 +38,12 @@ main() {
 
     test_title "Test that --shell validates its argument:"
     install 3.19.1 --shell foo
+
+    test_title "Test that --debug-override-url requires an argument:"
+    install 3.19.1 --debug-override-url
+
+    test_title "Test that --debug-tarball-dir requires an argument:"
+    install 3.19.1 --debug-tarball-dir
 }
 
 main "$@" 2>&1


### PR DESCRIPTION
This is intended to help us test changes to https://github.com/ocaml-dune/dune-bin using a local web server.