### PR TITLE
Infer the user's shell from the parent command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   not installed (#18)
 - When the version number is omitted, choose the latest _stable_ version of
   dune (#21).
+- Infer the user's shell when from the parent process's command when the
+  `$SHELL` environment variable is unset (#25).
 
 ### Added
 

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -465,6 +465,122 @@ RUN git -C /dune-versions tag 0.11.0_alpha && \
 
 
 ###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is sh.
+FROM base AS test17
+RUN apk update && apk add curl expect
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN sh -c "/interactive_generic.tcl /install.sh $DUNE_VERSION '' ''; :"
+RUN grep env\.sh ~/.profile
+
+
+
+###############################################################################
+#Test that the install script correctly infers the shell when the SHELL
+#environment variable is not set when the shell is ash (a minimal posix shell
+#which should be handled the same as sh).
+FROM base AS test18
+RUN apk update && apk add curl expect
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN ash -c "/interactive_generic.tcl /install.sh $DUNE_VERSION '' ''; :"
+RUN grep env\.sh ~/.profile
+
+
+
+###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is dash (a minimal posix shell
+# which should be handled the same as sh).
+FROM base AS test19
+RUN apk update && apk add curl expect dash
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN dash -c "/interactive_generic.tcl /install.sh $DUNE_VERSION '' ''; :"
+RUN grep env\.sh ~/.profile
+
+
+
+###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is bash.
+FROM base AS test20
+RUN apk update && apk add curl expect bash
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN bash -c "/interactive_generic.tcl /install.sh $DUNE_VERSION '' ''; :"
+RUN grep env\.bash ~/.profile
+
+
+
+###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is zsh.
+FROM base AS test21
+RUN apk update && apk add curl expect zsh
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN zsh -c "/interactive_generic.tcl /install.sh $DUNE_VERSION '' ''; :"
+RUN grep env\.zsh ~/.zshrc
+
+
+
+###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is fish.
+FROM base AS test22
+RUN apk update && apk add curl expect fish
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN fish -c "/interactive_generic.tcl /install.sh $DUNE_VERSION '' ''; :"
+RUN grep env\.fish ~/.config/fish/config.fish
+
+
+
+###############################################################################
 # Final stage that copies the install scripts from the previous stage to force
 # them to be rerun after the script changes. Docker won't rerun stages which
 # don't affect the final stage, even if their inputs change.
@@ -485,3 +601,9 @@ COPY --from=test13 /install.sh .
 COPY --from=test14 /install.sh .
 COPY --from=test15 /install.sh .
 COPY --from=test16 /install.sh .
+COPY --from=test17 /install.sh .
+COPY --from=test18 /install.sh .
+COPY --from=test19 /install.sh .
+COPY --from=test20 /install.sh .
+COPY --from=test21 /install.sh .
+COPY --from=test22 /install.sh .

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -581,6 +581,126 @@ RUN grep env\.fish ~/.config/fish/config.fish
 
 
 ###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is sh, avoiding the use of
+# expect.
+FROM base AS test23
+RUN apk update && apk add curl expect
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN sh -c "yes '' | /install.sh --no-tty $DUNE_VERSION; :"
+RUN grep env\.sh ~/.profile
+
+
+
+###############################################################################
+#Test that the install script correctly infers the shell when the SHELL
+#environment variable is not set when the shell is ash (a minimal posix shell
+#which should be handled the same as sh), avoiding the use of expect.
+FROM base AS test24
+RUN apk update && apk add curl expect
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN ash -c "yes '' | /install.sh --no-tty $DUNE_VERSION; :"
+RUN grep env\.sh ~/.profile
+
+
+
+###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is dash (a minimal posix shell
+# which should be handled the same as sh), avoiding the use of expect.
+FROM base AS test25
+RUN apk update && apk add curl expect dash
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN dash -c "yes '' | /install.sh --no-tty $DUNE_VERSION; :"
+RUN grep env\.sh ~/.profile
+
+
+
+###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is bash, avoiding the use of
+# expect.
+FROM base AS test26
+RUN apk update && apk add curl expect bash
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN bash -c "yes '' | /install.sh --no-tty $DUNE_VERSION; :"
+RUN grep env\.bash ~/.profile
+
+
+
+###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is zsh, avoiding the use of
+# expect.
+FROM base AS test27
+RUN apk update && apk add curl expect zsh
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN zsh -c "yes '' | /install.sh --no-tty $DUNE_VERSION; :"
+RUN grep env\.zsh ~/.zshrc
+
+
+
+###############################################################################
+# Test that the install script correctly infers the shell when the SHELL
+# environment variable is not set when the shell is fish, avoiding the use of
+# expect.
+FROM base AS test28
+RUN apk update && apk add curl expect fish
+COPY interactive_generic.tcl .
+RUN adduser -D user
+USER user
+WORKDIR /home/user
+
+# Run the interactive installer in a shell. The final ':' is a noop to force
+# the installer to run in a child process of bash, preventing the shell from
+# exec-ing into expect instead. This simulates running the interactive
+# installer from the command-line.
+RUN fish -c "yes '' | /install.sh --no-tty $DUNE_VERSION; :"
+RUN grep env\.fish ~/.config/fish/config.fish
+
+
+
+###############################################################################
 # Final stage that copies the install scripts from the previous stage to force
 # them to be rerun after the script changes. Docker won't rerun stages which
 # don't affect the final stage, even if their inputs change.
@@ -607,3 +727,9 @@ COPY --from=test19 /install.sh .
 COPY --from=test20 /install.sh .
 COPY --from=test21 /install.sh .
 COPY --from=test22 /install.sh .
+COPY --from=test23 /install.sh .
+COPY --from=test24 /install.sh .
+COPY --from=test25 /install.sh .
+COPY --from=test26 /install.sh .
+COPY --from=test27 /install.sh .
+COPY --from=test28 /install.sh .

--- a/test_errors.expected_output
+++ b/test_errors.expected_output
@@ -20,6 +20,7 @@ Options:
 --shell-config PATH       Use this file as your shell config when updating the shell config
 --shell SHELL             One of: bash, zsh, fish, sh. Installer will treat this as your shell. Use 'sh' for minimal posix shells such as ash
 --just-print-version      Make no changes to the system. The final line of stdout will be the version of dune that would have been installed
+--no-tty                  Read interactive input from stdin rather than the terminal device (allows automation via yes et al.)
 --debug-override-url URL  Download dune tarball from given url (debugging only)
 --debug-tarball-dir DIR   Name of root directory inside tarball (debugging only)
 --debug-version-repo REPO Override the git repo url used to determine the latest version of dune (debugging only)


### PR DESCRIPTION
The previous approach of determining the shell from the $SHELL environment variable almost never worked in practice. This is because $SHELL is usually not an environment variable but a "shell variable", and this is not inherited into the install script environment.

Following the approach of `opam init`, this change infers the user's shell from the parent process of the install script. In the common case where the script is run from the command line, the user's shell will be the parent process of the install script. This change also includes handling for the case where the script is run by `expect`, since that is how we test the interactive elements of the install script.