### PR TITLE
Force ipv4 when downloading from github

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Fixed
+
+- Force ipv4 when downloading from github. (#27)
+
 ## v2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Paste this into your terminal to install Dune:
 ```
-curl -fsSL https://github.com/ocaml-dune/dune-bin-install/releases/download/v2/install.sh | sh
+curl -4fsSL https://github.com/ocaml-dune/dune-bin-install/releases/download/v2/install.sh | sh
 ```
 
 No installation of opam or OCaml is necessary. Dune will be installed under `~/.local` by default.
@@ -22,7 +22,7 @@ when building a docker image. To do this, run the script with
 For example to install Dune while building a docker image from a Dockerfile,
 assuming `curl` is installed and the current user is root, one could use:
 ```dockerfile
-RUN curl -fsSL https://github.com/ocaml-dune/dune-bin-install/releases/download/v2/install.sh | sh -s 3.19.1 --install-root /usr --no-update-shell-config
+RUN curl -4fsSL https://github.com/ocaml-dune/dune-bin-install/releases/download/v2/install.sh | sh -s 3.19.1 --install-root /usr --no-update-shell-config
 ```
 Note the `--install-root /usr`, which causes dune to be installed system-wide,
 with its executable installed to `/usr/bin/dune`. Since `/usr/bin` is almost

--- a/install.sh
+++ b/install.sh
@@ -441,7 +441,7 @@ main () {
     fi
     curl --fail --location --progress-bar \
         --proto "$curl_proto" --tlsv1.2 \
-        --output "$tmp_tar" "$tar_uri" ||
+        --output "$tmp_tar" --ipv4 "$tar_uri" ||
         error_download_failed "$tar_uri" "$version"
 
     tar -xf "$tmp_tar" -C "$tmp_dir" "$tar_owner" > /dev/null 2>&1 ||


### PR DESCRIPTION
Github doesn't support ipv6 yet and it appears under some conditions curl tries to access github with ipv6.

For context, see https://github.com/ocaml/ocaml.org/pull/3281#issuecomment-3233314124